### PR TITLE
Updated VertiGIS Mobile version number to 5.28

### DIFF
--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.Android/VertiGIS.Mobile.Samples.Android.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.Android/VertiGIS.Mobile.Samples.Android.csproj
@@ -66,7 +66,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.27.0.280</Version>
+      <Version>5.28.0.203</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.UWP/VertiGIS.Mobile.Samples.UWP.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.UWP/VertiGIS.Mobile.Samples.UWP.csproj
@@ -194,7 +194,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.27.0.280</Version>
+      <Version>5.28.0.203</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/VertiGIS.Mobile.Samples.iOS.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/VertiGIS.Mobile.Samples.iOS.csproj
@@ -198,7 +198,7 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.27.0.280</Version>
+      <Version>5.28.0.203</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/VertiGIS.Mobile.Samples.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/VertiGIS.Mobile.Samples.csproj
@@ -172,7 +172,7 @@
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.15.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="VertiGIS.Mobile" Version="5.27.0.280" />
+    <PackageReference Include="VertiGIS.Mobile" Version="5.28.0.203" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
   </ItemGroup>
 


### PR DESCRIPTION
Update the VertiGIS Mobile version number from 5.27.0.280 to 5.28.0.203