### PR TITLE
Add privacy info file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             - uses: actions/checkout@v2
 
             # Fixes error when using newer NuGet packages that require a minimum version of Xcode
-            - name: Use Xcode 14.0.1
+            - name: Use Latest Xcode
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: 14.0.1
+                  xcode-version: latest
 
             # The following two workaround steps can be removed when the following github issue is resolved: https://github.com/actions/virtual-environments/issues/5768
             - name: Restore Workaround Remove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,15 @@ jobs:
               run: msbuild
               working-directory: Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.Android
     iOS:
-        runs-on: macos-latest
+        runs-on: macos-12
         steps:
             - uses: actions/checkout@v2
 
             # Fixes error when using newer NuGet packages that require a minimum version of Xcode
-            - name: Use Xcode 14.3.1
+            - name: Use Latest Xcode
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: 14.3.1
+                  xcode-version: latest
 
             # The following two workaround steps can be removed when the following github issue is resolved: https://github.com/actions/virtual-environments/issues/5768
             - name: Restore Workaround Remove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             - uses: actions/checkout@v2
 
             # Fixes error when using newer NuGet packages that require a minimum version of Xcode
-            - name: Use Xcode 14
+            - name: Use Xcode 14.3.1
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: 14.x
+                  xcode-version: 14.3.1
 
             # The following two workaround steps can be removed when the following github issue is resolved: https://github.com/actions/virtual-environments/issues/5768
             - name: Restore Workaround Remove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             - uses: actions/checkout@v2
 
             # Fixes error when using newer NuGet packages that require a minimum version of Xcode
-            - name: Use Latest Xcode
+            - name: Use Xcode 14
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: latest
+                  xcode-version: 14.x
 
             # The following two workaround steps can be removed when the following github issue is resolved: https://github.com/actions/virtual-environments/issues/5768
             - name: Restore Workaround Remove

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/PrivacyInfo.xcprivacy
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>NSPrivacyAccessedAPITypes</key>
+		<array>
+			<dict>
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>C617.1</string>
+				</array>
+			</dict>
+			<dict>
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>35F9.1</string>
+				</array>
+			</dict>
+			<dict>
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>E174.1</string>
+				</array>
+			</dict>
+		</array>
+	</dict>
+</plist>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/VertiGIS.Mobile.Samples.iOS.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/VertiGIS.Mobile.Samples.iOS.csproj
@@ -123,6 +123,7 @@
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <BundleResource Include="Resources\NLog.config" />
+    <BundleResource Include="PrivacyInfo.xcprivacy" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />


### PR DESCRIPTION
Apple has introduced a new requirement that apps published through the store must contain a file, PrivacyInfo.xcprivacy, describing the reason for the use of certain APIs. This PR adds the required file to the quickstart as a demonstration for SDK users. Note that your own apps may need to include additional entries depending on what they're doing.