### PR TITLE
Update Samples App to 5.35 version of VertiGIS Studio Mobile

### DIFF
--- a/VSM.Samples/VSM.Samples.csproj
+++ b/VSM.Samples/VSM.Samples.csproj
@@ -310,7 +310,7 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.203" />
+		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.264" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/VSM.Samples/VSM.Samples.csproj
+++ b/VSM.Samples/VSM.Samples.csproj
@@ -7,7 +7,7 @@
 		<OutputType>Exe</OutputType>
 		<RootNamespace>VSM.Samples</RootNamespace>
 		<UseMaui>true</UseMaui>
-		<MauiVersion>8.0.70</MauiVersion>
+		<MauiVersion>8.0.82</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -310,7 +310,7 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.264" />
+		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.277" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/VSM.Samples/VSM.Samples.csproj
+++ b/VSM.Samples/VSM.Samples.csproj
@@ -310,7 +310,7 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.34.0.284" />
+		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.203" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />


### PR DESCRIPTION
Update Samples App to 5.35 version of VertiGIS Studio Mobile. Currently set to the latest RC (5.35.0.203), make sure to update the version if a newer RC is produced.