### PR TITLE
Update mobile package to 5.38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             - name: Use Latest Xcode
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: '16.x'
+                  xcode-version: '26.0.1'
 
             - name: Install .NET MAUI Workload
               run: dotnet workload install maui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               run: msbuild
               working-directory: VSM.Samples
     iOS:
-        runs-on: macos-15
+        runs-on: macos-16
         steps:
             - uses: actions/checkout@v2
 
@@ -43,7 +43,7 @@ jobs:
               run: dotnet workload install maui
 
             - name: Build
-              run: dotnet publish -f net8.0-ios /p:EnableCodeSigning=false
+              run: dotnet publish -f net9.0-ios /p:EnableCodeSigning=false
               working-directory: VSM.Samples
     Windows:
         runs-on: windows-latest
@@ -59,5 +59,5 @@ jobs:
                 winsdk-build-version: 19041
 
             - name: Build
-              run: dotnet publish -f net8.0-windows10.0.19041.0
+              run: dotnet publish -f net9.0-windows10.0.19041.0
               working-directory: VSM.Samples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               run: msbuild
               working-directory: VSM.Samples
     iOS:
-        runs-on: macos-16
+        runs-on: macos-15
         steps:
             - uses: actions/checkout@v2
 

--- a/VSM.Samples/VSM.Samples.csproj
+++ b/VSM.Samples/VSM.Samples.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 
 		<OutputType>Exe</OutputType>
 		<RootNamespace>VSM.Samples</RootNamespace>
 		<UseMaui>true</UseMaui>
-		<MauiVersion>8.0.82</MauiVersion>
+		<MauiVersion>9.0.90</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -28,7 +28,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'=='net8.0-ios'">
+	<PropertyGroup Condition="'$(TargetFramework)'=='net9.0-ios'">
 	  <ProvisioningType>manual</ProvisioningType>
 	  <CodesignProvision>VS: WildCard Development</CodesignProvision>
 	</PropertyGroup>
@@ -247,10 +247,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<Compile Update="AppResources.Designer.cs">
 			<DependentUpon>AppResources.resx</DependentUpon>
 			<DesignTime>True</DesignTime>
@@ -307,9 +303,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
-		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.37.0.232" />
+		<PackageReference Include="Esri.ArcGISRuntime" Version="200.7.0" />
+		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.7.0" />
+		<PackageReference Include="VertiGIS.Mobile" Version="5.38.0.210" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/VSM.Samples/VSM.Samples.csproj
+++ b/VSM.Samples/VSM.Samples.csproj
@@ -305,7 +305,7 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.7.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.7.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.38.0.210" />
+		<PackageReference Include="VertiGIS.Mobile" Version="5.38.0.237" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/VSM.Samples/VSM.Samples.csproj
+++ b/VSM.Samples/VSM.Samples.csproj
@@ -29,6 +29,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net9.0-ios'">
+	  <SkipStaticLibraryValidation>warn</SkipStaticLibraryValidation>
 	  <ProvisioningType>manual</ProvisioningType>
 	  <CodesignProvision>VS: WildCard Development</CodesignProvision>
 	</PropertyGroup>
@@ -305,7 +306,7 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.7.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.7.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.38.0.237" />
+		<PackageReference Include="VertiGIS.Mobile" Version="5.38.1.292" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />


### PR DESCRIPTION
- Update VSM package to 5.38
- Update project to .NET 9
- Update ArcGISRuntime to 200.7 to match Mobile
- Add `SkipStaticLibraryValidation` to resolve an exception when building iOS
- Set Maui version 9.0.90.